### PR TITLE
CircleCI: Speclj interface requires run.standard

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,3 @@
+test:
+  override:
+    - lein spec

--- a/spec/gatekeeper/core_spec.clj
+++ b/spec/gatekeeper/core_spec.clj
@@ -1,7 +1,8 @@
 (ns gatekeeper.core-spec
   (:require [speclj.core :refer :all]
             [gatekeeper.core :refer :all]
-            [gatekeeper.authenticators.core :as auth]))
+            [gatekeeper.authenticators.core :as auth]
+            speclj.run.standard))
 
 (defn proxy-request [request]
   (if (:authenticated request)


### PR DESCRIPTION
:information_desk_person: As per FundingCircle/factory-time#3, the interface for Speclj changed in v3.0.0 and now requires `speclj.run.standard` to be loaded.

Also added CircleCI configuration to have the task runner run the correct test suite.